### PR TITLE
Parse ERB in database.yml

### DIFF
--- a/bin/rails_pg_restore
+++ b/bin/rails_pg_restore
@@ -1,10 +1,12 @@
 #!/usr/bin/env ruby
 
 require 'yaml'
+require 'erb'
 require 'optparse'
+require_relative "#{Dir.pwd}/config/environment"
 
 begin
-  db_config = YAML.load_file('config/database.yml')
+  db_config = YAML.load(ERB.new(File.read('config/database.yml')).result)
 rescue
   puts "Database config couldn't be read, please make sure there is a config/database.yml"
 end

--- a/test/rails_pg_restore_test.rb
+++ b/test/rails_pg_restore_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'rails_pg_restore'
 
 class RailsPgRestoreTest < Minitest::Test
   def test_that_it_has_a_version_number
@@ -8,4 +9,9 @@ class RailsPgRestoreTest < Minitest::Test
   def test_it_does_something_useful
     assert false
   end
+
+  def test_that_it_parses_erb_in_yml
+    assert false
+  end
 end
+


### PR DESCRIPTION
Adds the ability to parse ERB nested in `config/database.yml`, and can
load any any ENV variables that might be declared in the rails ENV.

Basically, we can now understand statements like this:

```
  username: <% ENV['DB_USERNAME'] %>
  password: <% ENV['DB_PASSWORD'] %>
```